### PR TITLE
fix: add verification to avoid the duplicate notification sending

### DIFF
--- a/Service/NotificationService.php
+++ b/Service/NotificationService.php
@@ -63,13 +63,28 @@ class NotificationService
 
         // Only send notification if status has changed
         $lastNotificationStatus = $payment->getAdditionalInformation('koin_last_notification_status') ?? '';
-        if ($lastNotificationStatus !== $notificationStatus) {
+        $shouldNotifyOrder = ($lastNotificationStatus !== $notificationStatus);
+
+        $antifraudNotificationStatus = $payment->getAdditionalInformation('koin_antifraud_notification_status') ?? '';
+        $shouldNotifyAntifraud = ($antifraudNotificationStatus !== $notificationStatus);
+
+        if ($shouldNotifyOrder) {
+            $payment->setAdditionalInformation('koin_last_notification_status', $notificationStatus);
             $this->notifyOrder($order, $notificationStatus);
         }
 
-        $antifraudNotificationStatus = $payment->getAdditionalInformation('koin_antifraud_notification_status') ?? '';
-        if ($antifraudNotificationStatus !== $notificationStatus) {
+        if ($shouldNotifyAntifraud) {
+            $payment->setAdditionalInformation('koin_antifraud_notification_status', $notificationStatus);
             $this->notifyAntifraud($order, $notificationStatus);
+
+        }
+
+        if ($shouldNotifyAntifraud || $shouldNotifyOrder) {
+            try {
+                $this->orderRepository->save($order);
+            } catch (\Exception $e) {
+                $this->helper->log('Failed to save notification status: ' . $e->getMessage());
+            }
         }
     }
 
@@ -154,7 +169,6 @@ class NotificationService
         if ($order->getPayment()->getMethod() == ConfigProvider::CODE) {
             try {
                 $this->helperOrder->notification($order, $status);
-                $this->updateNotificationStatus($order, 'koin_last_notification_status', $status);
             } catch (\Exception $e) {
                 $this->helper->log('Failed to send order notification: ' . $e->getMessage());
             }
@@ -173,30 +187,9 @@ class NotificationService
         if ($this->helper->getAntifraudConfig('active')) {
             try {
                 $this->helperAntifraud->notification($order, $status);
-                $this->updateNotificationStatus($order, 'koin_antifraud_notification_status', $status);
             } catch (\Exception $e) {
                 $this->helper->log('Failed to send antifraud notification: ' . $e->getMessage());
             }
-        }
-    }
-
-    /**
-     * Update notification status in payment additional information
-     *
-     * @param Order $order
-     * @param string $key
-     * @param string $value
-     * @return void
-     */
-    private function updateNotificationStatus(Order $order, string $key, string $value): void
-    {
-        $payment = $order->getPayment();
-        $payment->setAdditionalInformation($key, $value);
-
-        try {
-            $this->orderRepository->save($order);
-        } catch (\Exception $e) {
-            $this->helper->log('Failed to save notification status: ' . $e->getMessage());
         }
     }
 }

--- a/Service/NotificationService.php
+++ b/Service/NotificationService.php
@@ -60,6 +60,7 @@ class NotificationService
         }
 
         $payment = $order->getPayment();
+        $wasNotified = false;
 
         // Only send notification if status has changed
         $lastNotificationStatus = $payment->getAdditionalInformation('koin_last_notification_status') ?? '';
@@ -71,15 +72,16 @@ class NotificationService
         if ($shouldNotifyOrder) {
             $payment->setAdditionalInformation('koin_last_notification_status', $notificationStatus);
             $this->notifyOrder($order, $notificationStatus);
+            $wasNotified = true;
         }
 
         if ($shouldNotifyAntifraud) {
             $payment->setAdditionalInformation('koin_antifraud_notification_status', $notificationStatus);
             $this->notifyAntifraud($order, $notificationStatus);
-
+            $wasNotified = true;
         }
 
-        if ($shouldNotifyAntifraud || $shouldNotifyOrder) {
+        if ($wasNotified) {
             try {
                 $this->orderRepository->save($order);
             } catch (\Exception $e) {


### PR DESCRIPTION
**Title:**

**Description:**
Some order notifications were sent to antifraud twice. Therefore, a verification was performed to prevent this behavior and ensure that notifications are sent only once.

**Checklist:**
- [ ] Changes are consistent with the project's coding style.
- [ ] Documentation (if applicable) has been updated.
- [ ] Link to related issue (if applicable):

**Testing Instructions:**

