### PR TITLE
fix: generate a new token for each payment attempt

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/cc.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cc.js
@@ -165,6 +165,10 @@ define([
                     return;
                 }
 
+                if (self.isPlaceOrderActionAllowed && self.isPlaceOrderActionAllowed() === false) {
+                    return;
+                }
+
                 totals.isLoading(true);
                 setPaymentInformationAction(self.messageContainer, self.getData())
                     .done(function () {
@@ -413,7 +417,11 @@ define([
             },
 
             handleKoinSuccess: function(data) {
-                this.cardToken(data.secure_token || '');
+                if (!data || !data.secure_token) {
+                    return;
+                }
+
+                this.cardToken(data.secure_token);
                 this.cardBin(data.bin || '');
                 this.cardLast4(data.last_four || '');
                 this.creditCardType(data.card_brand || '');
@@ -462,6 +470,10 @@ define([
                 this.isCardConfirmed(false);
                 this.showPciForm(true);
                 this.confirmedCardDisplay('');
+                this.cardToken('');
+                this.cardBin('');
+                this.cardLast4('');
+                this.creditCardType('');
 
                 // Reset installments dropdown
                 this.installments.removeAll();
@@ -477,22 +489,22 @@ define([
 
             tokenizeAndPlaceOrder: function() {
                 var self = this;
-                if (this.isPciCompliance) {
-                    if (this.isCardConfirmed()) {
-                        // Card already confirmed, place order directly
-                        this.placeOrder();
-                    } else {
-                        // Confirm card first, then place order
-                        this.koinCheckout.tokenize().then(function(data) {
-                            self.handleKoinSuccess(data);
-                            self.placeOrder();
-                        }).catch(function(error) {
-                            self.handleKoinError(error);
-                        });
-                    }
-                } else {
+                if (!this.isPciCompliance) {
                     this.placeOrder();
+                    return;
                 }
+
+                if (!this.koinCheckout) {
+                    return;
+                }
+
+                // Confirm card first, then place order
+                this.koinCheckout.tokenize().then(function (data) {
+                    self.handleKoinSuccess(data);
+                    self.placeOrder();
+                }).catch(function (error) {
+                    self.handleKoinError(error);
+                });
             },
 
             getCcIcons: function(type) {

--- a/view/frontend/web/js/view/payment/method-renderer/cc.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cc.js
@@ -489,6 +489,11 @@ define([
 
             tokenizeAndPlaceOrder: function() {
                 var self = this;
+
+                if (this.isPlaceOrderActionAllowed && this.isPlaceOrderActionAllowed() === false) {
+                    return;
+                }
+
                 if (!this.isPciCompliance) {
                     this.placeOrder();
                     return;


### PR DESCRIPTION
**Title:**

**Description:**
It's necessary to generate a new token for each payment attempt because, when a payment fails due to a misconfiguration and the user later fixes it, the token is not regenerated for the next attempt, causing the antifraud to return the error "Invalid Card".

**Checklist:**
- [ ] Changes are consistent with the project's coding style.
- [ ] Documentation (if applicable) has been updated.
- [ ] Link to related issue (if applicable):

**Testing Instructions:**
- Change the "Your Koin Account Number" to an incorrect account number;
- Try to place order (it will return an error);
- Change the "Your Koin Account Number" to a correct account number;
- Try to place order (it must be successful).
