### PR TITLE
feat: create a config to set the taxvat field as required

### DIFF
--- a/Gateway/Request/PaymentsRequest.php
+++ b/Gateway/Request/PaymentsRequest.php
@@ -24,6 +24,7 @@ use Koin\Payment\Gateway\Http\Client\Payments\Api;
 use Koin\Payment\Helper\Data;
 use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Payment\Gateway\ConfigInterface;
 use Magento\Catalog\Api\CategoryRepositoryInterface;
@@ -153,6 +154,9 @@ class PaymentsRequest
         return $transaction;
     }
 
+    /**
+     * @throws \Exception
+     */
     public function getPayerData(Order $order): \stdClass
     {
         $payerData = new \stdClass();
@@ -173,7 +177,10 @@ class PaymentsRequest
 
         $payerData->full_name = $fullName;
         $payerData->email = $order->getCustomerEmail();
-        $payerData->document = $this->getDocument($customerTaxVat);
+
+        $this->isTaxVatRequired($customerTaxVat);
+
+        $payerData->document = $customerTaxVat ? $this->getDocument($customerTaxVat) : '';
 
         $phoneNumber = $this->helper->formatPhoneNumber($address->getTelephone() ?: '');
         $payerData->phone = new \stdClass();
@@ -187,6 +194,7 @@ class PaymentsRequest
 
     /**
      * @param Order $order
+     * @throws \Exception
      */
     public function getBuyerData(Order $order): \stdClass
     {
@@ -201,7 +209,10 @@ class PaymentsRequest
         $buyerData->first_name = $order->getCustomerFirstname();
         $buyerData->last_name = $order->getCustomerLastname();
         $buyerData->email = $order->getCustomerEmail();
-        $buyerData->document = $this->getDocument($customerTaxVat);
+
+        $this->isTaxVatRequired($customerTaxVat);
+
+        $buyerData->document = $customerTaxVat ? $this->getDocument($customerTaxVat) : '';
 
         $phoneNumber = $this->helper->formatPhoneNumber($address->getTelephone() ?: '');
         $buyerData->phone = new \stdClass();
@@ -211,6 +222,17 @@ class PaymentsRequest
         $buyerData->address = $this->getAddress($address);
 
         return $buyerData;
+    }
+
+    /**
+     * @param string|null $customerTaxVat
+     * @throws LocalizedException
+     */
+    private function isTaxVatRequired(?string $customerTaxVat): void
+    {
+        if (!$customerTaxVat && $this->helper->getGeneralConfig('taxvat_required')) {
+            throw new LocalizedException(__('Customer taxvat is required.'));
+        }
     }
 
     /**

--- a/Gateway/Request/PaymentsRequest.php
+++ b/Gateway/Request/PaymentsRequest.php
@@ -180,7 +180,7 @@ class PaymentsRequest
 
         $this->isTaxVatRequired($customerTaxVat);
 
-        $payerData->document = $customerTaxVat ? $this->getDocument($customerTaxVat) : '';
+        $payerData->document = ($customerTaxVat !== null && trim($customerTaxVat) !== '') ? $this->getDocument($customerTaxVat) : '';
 
         $phoneNumber = $this->helper->formatPhoneNumber($address->getTelephone() ?: '');
         $payerData->phone = new \stdClass();
@@ -212,7 +212,7 @@ class PaymentsRequest
 
         $this->isTaxVatRequired($customerTaxVat);
 
-        $buyerData->document = $customerTaxVat ? $this->getDocument($customerTaxVat) : '';
+        $buyerData->document = ($customerTaxVat !== null && trim($customerTaxVat) !== '') ? $this->getDocument($customerTaxVat) : '';
 
         $phoneNumber = $this->helper->formatPhoneNumber($address->getTelephone() ?: '');
         $buyerData->phone = new \stdClass();
@@ -230,7 +230,8 @@ class PaymentsRequest
      */
     private function isTaxVatRequired(?string $customerTaxVat): void
     {
-        if (!$customerTaxVat && $this->helper->getGeneralConfig('taxvat_required')) {
+        if ($this->helper->getGeneralConfig('taxvat_required') &&
+            ($customerTaxVat === null || trim($customerTaxVat) === '')) {
             throw new LocalizedException(__('Customer taxvat is required.'));
         }
     }

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ *
+ *
+ *
+ *
+ *
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this extension to newer
+ * version in the future.
+ *
+ * @category    Koin
+ * @package     Koin_Payment
+ *
+ *
+ */
+
+namespace Koin\Payment\Model\Ui;
+
+use Koin\Payment\Helper\Data;
+use Magento\Checkout\Model\ConfigProviderInterface;
+
+class ConfigProvider implements ConfigProviderInterface
+{
+    const PAYMENT_KEY = 'koin';
+
+    public function __construct(
+        private readonly Data $helper
+    ) {}
+
+    public function getConfig(): array
+    {
+        return [
+            'payment' => [
+                self::PAYMENT_KEY => [
+                    'taxvat_required' => (bool) $this->helper->getConfig('taxvat_required', 'general', 'koin'),
+                ]
+            ]
+        ];
+    }
+}

--- a/etc/adminhtml/system/general.xml
+++ b/etc/adminhtml/system/general.xml
@@ -63,6 +63,13 @@
                 <comment><![CDATA[If your store shows the payment info at success page, DON'T enable this feature]]></comment>
             </field>
 
+            <field id="taxvat_required" translate="label comment" type="select" sortOrder="51" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Is Taxvat Field Required on Checkout?</label>
+                <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                <config_path>koin/general/taxvat_required</config_path>
+                <comment><![CDATA[If enabled, the customer must fill the Taxvat field on checkout]]></comment>
+            </field>
+
             <field id="debug" translate="label" type="select" sortOrder="55" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Enable Log Requests</label>
                 <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -19,6 +19,7 @@
             <general>
                 <refund_on_cancel>1</refund_on_cancel>
                 <show_payment_info>0</show_payment_info>
+                <taxvat_required>1</taxvat_required>
                 <sandbox_3ds_strategy>challenge</sandbox_3ds_strategy>
             </general>
             <payments>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -16,6 +16,7 @@
     <type name="Magento\Checkout\Model\CompositeConfigProvider">
         <arguments>
             <argument name="configProviders" xsi:type="array">
+                <item name="koin_config_provider" xsi:type="object">Koin\Payment\Model\Ui\ConfigProvider</item>
                 <item name="koin_redirect_config_provider" xsi:type="object">Koin\Payment\Model\Ui\Redirect\ConfigProvider</item>
                 <item name="koin_pix_config_provider" xsi:type="object">Koin\Payment\Model\Ui\Pix\ConfigProvider</item>
                 <item name="koin_cc_config_provider" xsi:type="object">Koin\Payment\Model\Ui\CreditCard\ConfigProvider</item>

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -306,3 +306,6 @@
 "Interest orders with 10 installments","Interest orders with 10 installments"
 "Interest orders with 11 installments","Interest orders with 11 installments"
 "Interest orders with 12 installments","Interest orders with 12 installments"
+"Is Taxvat Field Required on Checkout?","Is Taxvat Field Required on Checkout?"
+"If enabled, the customer must fill the Taxvat field on checkout","If enabled, the customer must fill the Taxvat field on checkout"
+"Customer taxvat is required.","Customer taxvat is required."

--- a/i18n/es_AR.csv
+++ b/i18n/es_AR.csv
@@ -310,3 +310,6 @@ Card Installments,Cuotas de la Tarjeta
 "Interest orders with 10 installments","Interés para pedidos con 10 cuotas"
 "Interest orders with 11 installments","Interés para pedidos con 11 cuotas"
 "Interest orders with 12 installments","Interés para pedidos con 12 cuotas"
+"Is Taxvat Field Required on Checkout?","¿El Campo de Documento es Obligatorio en el Checkout?"
+"If enabled, the customer must fill the Taxvat field on checkout","Si está habilitado, el cliente debe completar el campo Documento en el checkout"
+"Customer taxvat is required.","El documento del cliente es obligatorio."

--- a/i18n/es_CO.csv
+++ b/i18n/es_CO.csv
@@ -310,3 +310,6 @@ Card Installments,Cuotas de la Tarjeta
 "Interest orders with 10 installments","Interés para pedidos con 10 cuotas"
 "Interest orders with 11 installments","Interés para pedidos con 11 cuotas"
 "Interest orders with 12 installments","Interés para pedidos con 12 cuotas"
+"Is Taxvat Field Required on Checkout?","¿El Campo de Documento es Obligatorio en el Checkout?"
+"If enabled, the customer must fill the Taxvat field on checkout","Si está habilitado, el cliente debe completar el campo Documento en el checkout"
+"Customer taxvat is required.","El documento del cliente es obligatorio."

--- a/i18n/es_ES.csv
+++ b/i18n/es_ES.csv
@@ -310,3 +310,6 @@ Card Installments,Cuotas de la Tarjeta
 "Interest orders with 10 installments","Interés para pedidos con 10 cuotas"
 "Interest orders with 11 installments","Interés para pedidos con 11 cuotas"
 "Interest orders with 12 installments","Interés para pedidos con 12 cuotas"
+"Is Taxvat Field Required on Checkout?","¿El Campo de Documento es Obligatorio en el Checkout?"
+"If enabled, the customer must fill the Taxvat field on checkout","Si está habilitado, el cliente debe completar el campo Documento en el checkout"
+"Customer taxvat is required.","El documento del cliente es obligatorio."

--- a/i18n/es_MX.csv
+++ b/i18n/es_MX.csv
@@ -310,3 +310,6 @@ Card Installments,Cuotas de la Tarjeta
 "Interest orders with 10 installments","Interés para pedidos con 10 cuotas"
 "Interest orders with 11 installments","Interés para pedidos con 11 cuotas"
 "Interest orders with 12 installments","Interés para pedidos con 12 cuotas"
+"Is Taxvat Field Required on Checkout?","¿El Campo de Documento es Obligatorio en el Checkout?"
+"If enabled, the customer must fill the Taxvat field on checkout","Si está habilitado, el cliente debe completar el campo Documento en el checkout"
+"Customer taxvat is required.","El documento del cliente es obligatorio."

--- a/i18n/es_UR.csv
+++ b/i18n/es_UR.csv
@@ -310,3 +310,6 @@ Card Installments,Cuotas de la Tarjeta
 "Interest orders with 10 installments","Interés para pedidos con 10 cuotas"
 "Interest orders with 11 installments","Interés para pedidos con 11 cuotas"
 "Interest orders with 12 installments","Interés para pedidos con 12 cuotas"
+"Is Taxvat Field Required on Checkout?","¿El Campo de Documento es Obligatorio en el Checkout?"
+"If enabled, the customer must fill the Taxvat field on checkout","Si está habilitado, el cliente debe completar el campo Documento en el checkout"
+"Customer taxvat is required.","El documento del cliente es obligatorio."

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -313,3 +313,6 @@
 "Interest orders with 10 installments","Juros para pedidos com 10 parcelas"
 "Interest orders with 11 installments","Juros para pedidos com 11 parcelas"
 "Interest orders with 12 installments","Juros para pedidos com 12 parcelas"
+"Is Taxvat Field Required on Checkout?","O Campo Taxvat é Obrigatório no Checkout?"
+"If enabled, the customer must fill the Taxvat field on checkout","Se habilitado, o cliente deve preencher o campo CPF no checkout"
+"Customer taxvat is required.","O CPF do cliente é obrigatório."

--- a/view/frontend/web/js/view/payment/method-renderer/cc.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cc.js
@@ -199,6 +199,10 @@ define([
                 return this.item.method;
             },
 
+            isTaxvatRequired: function() {
+                return !!window.checkoutConfig.payment?.koin?.taxvat_required;
+            },
+
             /**
              * Get data
              * @returns {Object}

--- a/view/frontend/web/js/view/payment/method-renderer/pix.js
+++ b/view/frontend/web/js/view/payment/method-renderer/pix.js
@@ -28,6 +28,10 @@ define(
                 return 'koin_pix';
             },
 
+            isTaxvatRequired: function() {
+                return !!window.checkoutConfig.payment?.koin?.taxvat_required;
+            },
+
             getData: function() {
                 return {
                     'method': this.item.method,

--- a/view/frontend/web/js/view/payment/method-renderer/redirect.js
+++ b/view/frontend/web/js/view/payment/method-renderer/redirect.js
@@ -61,6 +61,10 @@ define(
                 return 'koin_redirect';
             },
 
+            isTaxvatRequired: function() {
+                return !!window.checkoutConfig.payment?.koin?.taxvat_required;
+            },
+
             logoOnCheckout: function() {
                 var inputClasses = 'radio';
                 if (window.checkoutConfig.payment.koin_redirect.show_logo_on_checkout) {

--- a/view/frontend/web/template/payment/form/cc.html
+++ b/view/frontend/web/template/payment/form/cc.html
@@ -258,7 +258,7 @@
                     </div>
                 </div>
 
-                <div class="field number required" data-bind="attr: {id: getCode() + '_taxat'}">
+                <div class="field number" data-bind="attr: {id: getCode() + '_taxat'}, css: {required: isTaxvatRequired()}">
                     <label data-bind="attr: {for: getCode() + '_taxvat'}" class="label">
                         <span><!-- ko i18n: 'Customer Taxvat' --><!-- /ko --></span>
                     </label>
@@ -272,7 +272,7 @@
                                         title: $t('Customer Taxvat'),
                                         maxlength: 11,
                                         'data-container': getCode() + '-taxvat',
-                                        'data-validate': JSON.stringify({'required':true, 'required-number':true})
+                                        'data-validate': JSON.stringify({'required': isTaxvatRequired(), 'required-number':true})
                                       },
                                       value: taxvat,
                                       valueUpdate: 'keyup' "/>

--- a/view/frontend/web/template/payment/form/pix.html
+++ b/view/frontend/web/template/payment/form/pix.html
@@ -18,7 +18,7 @@
                 </dd>
             </dl>
 
-            <div class="field number required" data-bind="attr: {id: getCode() + '_taxat'}">
+            <div class="field number" data-bind="attr: {id: getCode() + '_taxat'}, css: {required: isTaxvatRequired()}">
                 <label data-bind="attr: {for: getCode() + '_taxvat'}" class="label">
                     <span><!-- ko i18n: 'Customer Taxvat' --><!-- /ko --></span>
                 </label>
@@ -32,7 +32,7 @@
                                         title: $t('Customer Taxvat'),
                                         maxlength: 11,
                                         'data-container': getCode() + '-taxvat',
-                                        'data-validate': JSON.stringify({'required':true, 'required-number':true})
+                                        'data-validate': JSON.stringify({'required': isTaxvatRequired(), 'required-number':true})
                                       },
                                       value: taxvat,
                                       valueUpdate: 'keyup' "/>

--- a/view/frontend/web/template/payment/form/redirect.html
+++ b/view/frontend/web/template/payment/form/redirect.html
@@ -25,7 +25,7 @@
                 </dd>
             </dl>
 
-            <div class="field number required" data-bind="attr: {id: getCode() + '_taxat'}">
+            <div class="field number" data-bind="attr: {id: getCode() + '_taxat'}, css: {required: isTaxvatRequired()}">
                 <label data-bind="attr: {for: getCode() + '_taxvat'}" class="label">
                     <span><!-- ko i18n: 'Customer Taxvat' --><!-- /ko --></span>
                 </label>
@@ -39,7 +39,7 @@
                                         title: $t('Customer Taxvat'),
                                         maxlength: 11,
                                         'data-container': getCode() + '-taxvat',
-                                        'data-validate': JSON.stringify({'required':true, 'required-number':true})
+                                        'data-validate': JSON.stringify({'required': isTaxvatRequired(), 'required-number':true})
                                       },
                                       value: taxvat,
                                       valueUpdate: 'keyup' "/>


### PR DESCRIPTION
**Title:**

**Description:**
A new configuration was created to define whether the Tax/VAT field on the checkout should be required or optional.

**Checklist:**
- [ ] Changes are consistent with the project's coding style.
- [ ] Documentation (if applicable) has been updated.
- [ ] Link to related issue (if applicable):

**Testing Instructions:**
- Go to "Stores > Configuration > Sales > Payment Methods > Koin > General > Global Credentials and General Settings > Is Taxvat Field Required on Checkout?", set to "Yes/No" and clean the cache.
- Go to the checkout and verify whether the field is required or optional according to the configuration.
